### PR TITLE
Update to standard.py

### DIFF
--- a/standard.py
+++ b/standard.py
@@ -32,7 +32,7 @@ class MetaInfoStandard:
   @staticmethod
   def tryDetermineStandard(metaProvider):
     text = metaProvider.getMetadata()
-    print "TryDetStd ", text, " Text"
+    # print "TryDetStd ", text, " Text"
 
     # simple test for iso doc
     if text.find("MD_Metadata") >= 0 or text.find("MI_Metadata") >= 0:


### PR DESCRIPTION
Commenting out this line fixes the crash experienced in QGIS 2.2 +, the removal of the 'print' command doesn't seem to affect the overall plugin functionality.

See also: http://gis.stackexchange.com/questions/113250/qgis-metatools-error/116271#116271
